### PR TITLE
Returns original sentinel for same object and same delegate

### DIFF
--- a/Example/Tests/LOTLiveObjectCounterTests.m
+++ b/Example/Tests/LOTLiveObjectCounterTests.m
@@ -57,6 +57,31 @@ describe(@"LOTLiveObjectCounterSpecs", ^{
             expect(counter.count).to.equal(0);
         });
         
+        it(@"Count duplicated objects", ^{
+            LOTLiveObjectCounter *counter = [[LOTLiveObjectCounter alloc] init];
+            expect(counter.count).to.equal(0);
+            
+            waitUntil(^(DoneCallback done) {
+                NSObject *target1 = [[NSObject alloc] init];
+                [counter addObject:target1];
+                expect(counter.count).to.equal(1);
+                
+                [counter addObject:target1];
+                expect(counter.count).to.equal(1);
+                
+                NSObject *target2 = [[NSObject alloc] init];
+                [counter addObject:target2];
+                expect(counter.count).to.equal(2);
+                
+                [counter addObject:target2];
+                expect(counter.count).to.equal(2);
+                
+                done();
+            });
+            
+            expect(counter.count).to.equal(0);
+        });
+        
     });
     
     describe(@"w/ delegate", ^{

--- a/Example/Tests/LOTLiveObjectTracerSentinelTests.m
+++ b/Example/Tests/LOTLiveObjectTracerSentinelTests.m
@@ -33,34 +33,61 @@ SpecBegin(LOTLiveObjectTracerSentinelTests)
 
 describe(@"LOTLiveObjectTracerSentinelSpecs", ^{
     
-    it(@"addSentinelToObject", ^{
-        SentinelDelegate *delegate = [[SentinelDelegate alloc] init];
-        
-        waitUntil(^(DoneCallback done) {
-            NSObject *target = [[NSObject alloc] init];
-            [LOTLiveObjectTracerSentinel addSentinelToObject:target delegate:delegate];
-            expect(delegate.delegateCalled).to.beFalsy();
-            done();
+    describe(@"addSentinelToObject", ^{
+
+        it(@"addSentinelToObject", ^{
+            SentinelDelegate *delegate = [[SentinelDelegate alloc] init];
+            
+            waitUntil(^(DoneCallback done) {
+                NSObject *target = [[NSObject alloc] init];
+                [LOTLiveObjectTracerSentinel addSentinelToObject:target delegate:delegate];
+                expect(delegate.delegateCalled).to.beFalsy();
+                done();
+            });
+            
+            expect(delegate.delegateCalled).to.beTruthy();
         });
         
-        expect(delegate.delegateCalled).to.beTruthy();
-    });
-    
-    describe(@"sentinelWithObject", ^{
-        
-        it(@"Returns sentinel", ^{
+        it(@"Same sentinal for same delegate", ^{
             SentinelDelegate *delegate = [[SentinelDelegate alloc] init];
             NSObject *target = [[NSObject alloc] init];
+            
             LOTLiveObjectTracerSentinel *s1 = [LOTLiveObjectTracerSentinel addSentinelToObject:target delegate:delegate];
-            LOTLiveObjectTracerSentinel *s2 = [LOTLiveObjectTracerSentinel sentinelWithObject:target];
+            LOTLiveObjectTracerSentinel *s2 = [LOTLiveObjectTracerSentinel addSentinelToObject:target delegate:delegate];
             expect(s1).to.equal(s2);
         });
         
-        it(@"Returns nil", ^{
+        it(@"Differ sentinal for differ delegate", ^{
+            SentinelDelegate *delegate1 = [[SentinelDelegate alloc] init];
+            SentinelDelegate *delegate2 = [[SentinelDelegate alloc] init];
             NSObject *target = [[NSObject alloc] init];
-            LOTLiveObjectTracerSentinel *s = [LOTLiveObjectTracerSentinel sentinelWithObject:target];
-            expect(s).to.equal(nil);
+            
+            LOTLiveObjectTracerSentinel *s1 = [LOTLiveObjectTracerSentinel addSentinelToObject:target delegate:delegate1];
+            LOTLiveObjectTracerSentinel *s2 = [LOTLiveObjectTracerSentinel addSentinelToObject:target delegate:delegate2];
+            expect(s1).notTo.equal(s2);
         });
+        
+        it(@"Differ sentinal for differ target", ^{
+            SentinelDelegate *delegate = [[SentinelDelegate alloc] init];
+            NSObject *target1 = [[NSObject alloc] init];
+            NSObject *target2 = [[NSObject alloc] init];
+            
+            LOTLiveObjectTracerSentinel *s1 = [LOTLiveObjectTracerSentinel addSentinelToObject:target1 delegate:delegate];
+            LOTLiveObjectTracerSentinel *s2 = [LOTLiveObjectTracerSentinel addSentinelToObject:target2 delegate:delegate];
+            expect(s1).notTo.equal(s2);
+        });
+        
+        it(@"Differ sentinal for differ target and delegate", ^{
+            SentinelDelegate *delegate1 = [[SentinelDelegate alloc] init];
+            SentinelDelegate *delegate2 = [[SentinelDelegate alloc] init];
+            NSObject *target1 = [[NSObject alloc] init];
+            NSObject *target2 = [[NSObject alloc] init];
+            
+            LOTLiveObjectTracerSentinel *s1 = [LOTLiveObjectTracerSentinel addSentinelToObject:target1 delegate:delegate1];
+            LOTLiveObjectTracerSentinel *s2 = [LOTLiveObjectTracerSentinel addSentinelToObject:target2 delegate:delegate2];
+            expect(s1).notTo.equal(s2);
+        });
+        
     });
     
 });

--- a/LiveObjectTracer/Classes/LOTLiveObjectCounter.m
+++ b/LiveObjectTracer/Classes/LOTLiveObjectCounter.m
@@ -22,6 +22,10 @@
 - (void)addObject:(id)object
 {
     @synchronized (self) {
+        if ([LOTLiveObjectTracerSentinel sentinelWithObject:object delegate:self]) {
+            return;
+        }
+        
         NSUInteger prev = _count;
         [self willChangeValueForKey:@"count"];
         [LOTLiveObjectTracerSentinel addSentinelToObject:object delegate:self];

--- a/LiveObjectTracer/Classes/LOTLiveObjectTracerSentinel.h
+++ b/LiveObjectTracer/Classes/LOTLiveObjectTracerSentinel.h
@@ -42,7 +42,8 @@
 /*!
  @brief Returns the sentinel of the object if exist.
  @param object An object to trace living
+ @param delegate A delegate object
  */
-+ (instancetype _Nullable)sentinelWithObject:(id _Nonnull)object;
++ (instancetype _Nullable)sentinelWithObject:(id _Nonnull)object delegate:(id <LOTLiveObjectTracerSentinelDelegate> _Nonnull)delegate;
 
 @end

--- a/LiveObjectTracer/Classes/LOTLiveObjectTracerSentinel.m
+++ b/LiveObjectTracer/Classes/LOTLiveObjectTracerSentinel.m
@@ -4,22 +4,6 @@
 #import <objc/runtime.h>
 #import "LOTLiveObjectTracerSentinel.h"
 
-static const char * const associatedKey = "LOTLiveObjectTracer";
-
-/*!
- @brief Internal category
- */
-@interface LOTLiveObjectTracerSentinel ()
-
-/*!
- @brief Constructor with tracing target object and delegate object.
- @param object An object to trace living
- @param delegate A delegate object
- */
-- (instancetype _Nonnull)initWithObject:(id _Nonnull)object delegate:(id <LOTLiveObjectTracerSentinelDelegate> _Nonnull)delegate;
-
-@end
-
 @implementation LOTLiveObjectTracerSentinel
 
 - (instancetype)initWithObject:(id)object delegate:(id <LOTLiveObjectTracerSentinelDelegate>)delegate
@@ -27,7 +11,7 @@ static const char * const associatedKey = "LOTLiveObjectTracer";
     self = [super init];
     if (self) {
         self.delegate = delegate;
-        objc_setAssociatedObject(object, associatedKey, self, OBJC_ASSOCIATION_RETAIN);
+        objc_setAssociatedObject(object, (__bridge void *)delegate, self, OBJC_ASSOCIATION_RETAIN);
     }
     return self;
 }
@@ -41,12 +25,17 @@ static const char * const associatedKey = "LOTLiveObjectTracer";
 
 + (instancetype)addSentinelToObject:(id)object delegate:(id <LOTLiveObjectTracerSentinelDelegate>)delegate
 {
+    LOTLiveObjectTracerSentinel *sentinel = [self sentinelWithObject:object delegate:delegate];
+    if (sentinel) {
+        return sentinel;
+    }
     return [[LOTLiveObjectTracerSentinel alloc] initWithObject:object delegate:delegate];
 }
 
-+ (instancetype)sentinelWithObject:(id)object
++ (instancetype)sentinelWithObject:(id)object delegate:(id <LOTLiveObjectTracerSentinelDelegate>)delegate
+
 {
-    return (LOTLiveObjectTracerSentinel *)objc_getAssociatedObject(object, associatedKey);
+    return (LOTLiveObjectTracerSentinel *)objc_getAssociatedObject(object, (__bridge void *)delegate);
 }
 
 @end


### PR DESCRIPTION
This changes to fix duplicated count of LOTLiveObjectCounter.
I miss-understanded about associated key.